### PR TITLE
WIP: Add support for extended constructor

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-1.203 2017-05-18
+1.203 2017-09-20
 - Add option to provide extended attributes to the new Net::OpenSSH object
 - Add option to provide existing Net::OpenSSH object
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+1.203 2017-05-18
+- Add option to provide extended attributes to the new Net::OpenSSH object
+- Add option to provide existing Net::OpenSSH object
+
 1.202
 
 - SysFink (http://code.google.com/p/sysfink/) protocols are now based upon SSH::RPC.

--- a/lib/SSH/RPC/Client.pm
+++ b/lib/SSH/RPC/Client.pm
@@ -1,6 +1,6 @@
 package SSH::RPC::Client;
 
-our $VERSION = 1.201;
+our $VERSION = 1.203;
 
 use strict;
 use Class::InsideOut qw(readonly private id register);
@@ -64,12 +64,37 @@ The username you want to connect as.
 
 The password to connect to this account. Can be omitted if you've set up an ssh key to automatically authenticate. See man ssh-keygen for details.
 
+=head2 new ( \%opts )
+
+Extended constructor with Net::OpenSSH as parameter.
+
+=head3 \%opts
+
+The hash needs a key with name "host", that is the hostname or ip address you want to connect to.
+The remaining options in the hash will be used as optinal parameters for a new Net::OpenSSH object.
+
+=head2 new ( \$ssh )
+
+=head3 \$ssh
+
+Blessed reference holding an object that isa Net::OpenSSH, that will be reused for connection.
+
 =cut
 
 sub new {
-    my ($class, $host, $user, $pass) = @_;
+    my $class = shift;
     my $self = register($class);
-    $ssh{id $self} = Net::OpenSSH->new($host,user=>$user, password=>$pass, timeout=>30, master_opts => [ '-T']);
+    if (blessed($_[0]) and $_[0]->isa('Net::OpenSSH')) {
+        $ssh{id $self} = shift;
+    } elsif (ref($_[0]) eq 'HASH') {
+        my $opts = shift;
+        my $host = $opts->{host} or die "No host option specified";
+        delete $opts->{host};
+        $ssh{id $self} = Net::OpenSSH->new($host, %$opts);
+    } else {
+        my ($host, $user, $pass) = @_;
+        $ssh{id $self} = Net::OpenSSH->new($host,user=>$user, password=>$pass, timeout=>30, master_opts => [ '-T']);
+    }
     return $self;
 }
 


### PR DESCRIPTION
The constructor now can be called with:
 - a hash reference to be forwarded to the new Net::OpenSSH object
 - a blessed object which is a Net::OpenSSH