### PR TITLE
Fix not using Scalar::Util for ref checking

### DIFF
--- a/lib/SSH/RPC/Client.pm
+++ b/lib/SSH/RPC/Client.pm
@@ -1,9 +1,10 @@
 package SSH::RPC::Client;
 
-our $VERSION = 1.203;
+our $VERSION = 1.204;
 
 use strict;
 use Class::InsideOut qw(readonly private id register);
+use Scalar::Util qw(blessed);
 use JSON;
 use Net::OpenSSH;
 use SSH::RPC::Result;


### PR DESCRIPTION
When providing a Net::OpenSSH object to the constructor, blessed() is being used to check if the parameter is blessed or not.
This is provided by Scalar::Util core module but not loaded by use.